### PR TITLE
feat: remove Dashboard link from header navigation

### DIFF
--- a/components/header.tsx
+++ b/components/header.tsx
@@ -9,8 +9,8 @@ export function Header() {
     <header className="border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
       <div className="container flex h-14 items-center">
         <Link href="/" className="flex items-center space-x-2">
-          <LeafIcon className="h-6 w-6 text-emerald-600" />
-          <span className="font-bold">Avalúos Agrícolas</span>
+          <LeafIcon className="h-6 w-6 text-emerald-600 px-0 pl-0 ml-[25px]" />
+          <span className="font-bold pl-0">Avalúos Agrícolas</span>
         </Link>
         <div className="flex flex-1 items-center justify-end space-x-4">
           <UserMenu />


### PR DESCRIPTION
Clean up header structure by removing empty nav element.

#VERCEL_SKIP